### PR TITLE
Prevent inline code blocks from wrapping on hyphens

### DIFF
--- a/assets/docs/scss/custom/plugins/chroma/_default.scss
+++ b/assets/docs/scss/custom/plugins/chroma/_default.scss
@@ -2,6 +2,7 @@
 
 .docs-content .main-content code {
     color: var(--text-default);
+    white-space: nowrap;
 }
 
 .docs-content .main-content pre {


### PR DESCRIPTION
On pages with tables of attributes like https://developer.nibble.bot/docs/integration-guide/widget/, inline code is getting wrapped on hyphens, which makes them harder to read. This change prevents inline code blocks from wrapping.  See screenshots for before & after.

![image](https://github.com/user-attachments/assets/35d798fa-2376-419a-b0a3-0f21e58556a0)
![image](https://github.com/user-attachments/assets/f6a145b7-ad30-4328-a9c9-95a370b27ed7)
